### PR TITLE
fix(writemdict.py): use html instead of cgi

### DIFF
--- a/writemdict.py
+++ b/writemdict.py
@@ -30,7 +30,7 @@ from __future__ import unicode_literals
 import struct, zlib, operator, sys, datetime
 
 from ripemd128 import ripemd128
-from cgi import escape
+from html import escape
 from pureSalsa20 import Salsa20
 
 try:


### PR DESCRIPTION
# why

cgi.escape function was removed from python 3.8

cf: https://docs.python.org/3/whatsnew/3.8.html

# what

- use html instaed of cgi